### PR TITLE
1.15pre1 update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.2.5-SNAPSHOT'
+	id 'fabric-loom' version '0.2.6-SNAPSHOT'
 	id 'maven-publish'
 	id 'com.github.johnrengelman.shadow' version '4.0.0'
 }
@@ -16,6 +16,7 @@ minecraft {
 }
 
 repositories {
+	maven { url = "https://maven.fabricmc.net/" }
 	maven { url "https://minecraft.curseforge.com/api/maven" }
 }
 
@@ -30,16 +31,8 @@ dependencies {
 	modCompile "net.fabricmc.fabric-api:fabric-networking-v0:+"
 	include "net.fabricmc.fabric-api:fabric-networking-v0:+"
 
-	/*modImplementation("me.shedaniel:RoughlyEnoughItems:3.1.5-unstable.201910101247") {
-		exclude module: "modmenu"
-	}*/
-}
-
-sourceSets {
-	main {
-		java {
-			exclude "de/siphalor/nbtcrafting/client/rei/**"
-		}
+	modCompile("me.shedaniel:RoughlyEnoughItems:3.2.9-unstable.201911220940") {
+		exclude module: "autoconfig1u"
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=19w42a
-	yarn_mappings=1
-	loader_version=0.6.3+build.167
+	minecraft_version=1.15-pre1
+	yarn_mappings=3:v2
+	loader_version=0.7.1+build.173
 
 # Mod Properties
-	mod_version = 1.2.5
+	mod_version = 1.2.6
 	mod_id = nbtcrafting
 	maven_group = de.siphalor
 	archives_base_name = nbtcrafting


### PR DESCRIPTION
Updates project from 19w42a to 1.15-pre1. Loom updated to 0.2.6 to support v2 mappings. I think the 19w42a build was failing on 1.15-pre1 because the refmap was outdated.

I removed the REI plugin exclusion block and re-added a REI modCompile for 1.15-pre1.  For some odd reason, REI was trying to pull autoconfig, so I added it to the exclusion block.