### PR TITLE
Fix threading issue in recipe synchronization

### DIFF
--- a/src/main/java/de/siphalor/nbtcrafting/NbtCrafting.java
+++ b/src/main/java/de/siphalor/nbtcrafting/NbtCrafting.java
@@ -111,12 +111,14 @@ public class NbtCrafting implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		ServerSidePacketRegistry.INSTANCE.register(PRESENCE_PACKET_ID, (packetContext, packetByteBuf) -> {
-			ServerPlayerEntity serverPlayerEntity = (ServerPlayerEntity) packetContext.getPlayer();
-			((IServerPlayerEntity) serverPlayerEntity).setClientModPresent(true);
-			serverPlayerEntity.networkHandler.sendPacket(new SynchronizeRecipesS2CPacket(serverPlayerEntity.server.getRecipeManager().values()));
-			serverPlayerEntity.getRecipeBook().sendInitRecipesPacket(serverPlayerEntity);
-		});
+		ServerSidePacketRegistry.INSTANCE.register(PRESENCE_PACKET_ID, (packetContext, packetByteBuf) ->
+			packetContext.getTaskQueue().execute(() -> {
+				ServerPlayerEntity serverPlayerEntity = (ServerPlayerEntity) packetContext.getPlayer();
+				((IServerPlayerEntity) serverPlayerEntity).setClientModPresent(true);
+				serverPlayerEntity.networkHandler.sendPacket(new SynchronizeRecipesS2CPacket(serverPlayerEntity.server.getRecipeManager().values()));
+				serverPlayerEntity.getRecipeBook().sendInitRecipesPacket(serverPlayerEntity);
+			})
+		);
 	}
 
 	public static boolean hasClientMod(ServerPlayerEntity playerEntity) {


### PR DESCRIPTION
## Description

Fixes https://github.com/Siphalor/nbt-crafting/issues/66.
The paste.ee in the issue is expired but Google cache brought me to it.
Here's an up-to-date log from my server: https://paste.ee/p/YIw8x

When `HashSet.toArray` fails due to `ArrayIndexOutOfBoundsException`, this can only mean the set is concurrently modified.
The set in question is the recipe set.

Since the server I'm on unlocks player recipes on join, it was pretty obvious what happened:
The recipes are unlocked on the server thread while NBT Crafting calls `sendInitRecipesPacket`, which makes a copy of all recipes, on a Netty thread.

The fix is to use `packetContext.getTaskQueue().execute(() -> ...` so the latter runs on the server thread as well.
(Btw, I'm assuming you're using the legacy networking API because of 1.14?)

I verified via logging.
Before:
> 12:08:11 [DEBUG/Server thread] [Test] unlocking all recipes
> 12:08:12 [DEBUG/Netty Server IO 1] [NbtCrafting] synchronizing recipes

After:
> 12:19:57 [DEBUG/Server thread] [Test] unlocking all recipes
> 12:20:00 [DEBUG/Server thread] [NbtCrafting] synchronizing recipes
